### PR TITLE
Use complete SONAME in dlopen

### DIFF
--- a/src/tsdl_image.ml
+++ b/src/tsdl_image.ml
@@ -29,7 +29,7 @@ end
    in the toplevel, see
    https://github.com/ocamllabs/ocaml-ctypes/issues/70 *)
 let foreign name typ =
-  foreign name typ ~from:Dl.(dlopen ~filename:"libSDL2_image-2.0.so"
+  foreign name typ ~from:Dl.(dlopen ~filename:"libSDL2_image-2.0.so.0"
                                ~flags:[RTLD_NOW])
 let init =
   foreign "IMG_Init" (uint32_t @-> returning uint32_t)


### PR DESCRIPTION
Thanks for taking over the maintenance of these packages!

On my system (Manjaro), commit f70eabb7958500c46b951da52a1e4bf56cd00d9b broke runtime execution: the specified filename `libSDL2_image-2.0.so` does not exist. Indeed in my understanding the soname that is guaranteed to exist should be `libSDL2_image-2.0.so.0` (as returned by `objdump -p /usr/lib/libSDL2_image-2.0.so.0.2.3 | grep SONAME`).

I do not have multiple systems to check that this assumption is true but this is what I gather from the usual shared object conventions.

NOTE: there is the same issue on tsdl-mixer and ttf. I'm not opening PRs there to avoid spamming but this should also be fixed eventually.

-------

On a side note, where should potential issues be reported in the future? Currently you have not enabled Issues on this repo so I assume issues should still be reported at tokenrove's? 