### PR TITLE
Detect system, use it to pick the right extension for the shared library

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,14 @@
 (library
   (name tsdl_image)
   (public_name tsdl-image)
-  (modules tsdl_image)
+  (modules tsdl_image build_config)
+  (private_modules build_config)
   (libraries ctypes tsdl)
   (c_library_flags -lSDL2_image))
+
+(rule
+  (target build_config.ml)
+  (action
+    (with-stdout-to
+      %{target}
+      (echo "let system = \"%{system}\""))))

--- a/src/tsdl_image.ml
+++ b/src/tsdl_image.ml
@@ -29,7 +29,12 @@ end
    in the toplevel, see
    https://github.com/ocamllabs/ocaml-ctypes/issues/70 *)
 let foreign name typ =
-  foreign name typ ~from:Dl.(dlopen ~filename:"libSDL2_image-2.0.so.0"
+  let filename =
+    match Build_config.system with
+      | "macosx" -> "libSDL2_image-2.0.0.dylib"
+      | _ -> "libSDL2_image-2.0.so.0"
+  in
+  foreign name typ ~from:Dl.(dlopen ~filename
                                ~flags:[RTLD_NOW])
 let init =
   foreign "IMG_Init" (uint32_t @-> returning uint32_t)

--- a/src/tsdl_image.ml
+++ b/src/tsdl_image.ml
@@ -28,16 +28,18 @@ end
    #require "tsdl-image"
    in the toplevel, see
    https://github.com/ocamllabs/ocaml-ctypes/issues/70 *)
-let dllib =
-  let filename =
-    match Build_config.system with
-      | "macosx" -> "libSDL2_image-2.0.0.dylib"
-      | _ -> "libSDL2_image-2.0.so.0"
-  in
-  Dl.(dlopen ~filename ~flags:[RTLD_NOW])
-
 let foreign name typ =
-  foreign name typ ~from:dllib
+  if !Sys.interactive then (
+    let dllib =
+      let filename =
+        match Build_config.system with
+          | "macosx" -> "libSDL2_image-2.0.0.dylib"
+          | _ -> "libSDL2_image-2.0.so.0"
+      in
+      Dl.(dlopen ~filename ~flags:[RTLD_NOW])
+    in
+    foreign name typ ~from:dllib)
+  else foreign name typ
 
 let init =
   foreign "IMG_Init" (uint32_t @-> returning uint32_t)

--- a/src/tsdl_image.ml
+++ b/src/tsdl_image.ml
@@ -28,14 +28,17 @@ end
    #require "tsdl-image"
    in the toplevel, see
    https://github.com/ocamllabs/ocaml-ctypes/issues/70 *)
-let foreign name typ =
+let dllib =
   let filename =
     match Build_config.system with
       | "macosx" -> "libSDL2_image-2.0.0.dylib"
       | _ -> "libSDL2_image-2.0.so.0"
   in
-  foreign name typ ~from:Dl.(dlopen ~filename
-                               ~flags:[RTLD_NOW])
+  Dl.(dlopen ~filename ~flags:[RTLD_NOW])
+
+let foreign name typ =
+  foreign name typ ~from:dllib
+
 let init =
   foreign "IMG_Init" (uint32_t @-> returning uint32_t)
 

--- a/src/tsdl_image.ml
+++ b/src/tsdl_image.ml
@@ -28,18 +28,18 @@ end
    #require "tsdl-image"
    in the toplevel, see
    https://github.com/ocamllabs/ocaml-ctypes/issues/70 *)
-let foreign name typ =
+let dllib : Dl.library option =
   if !Sys.interactive then (
-    let dllib =
-      let filename =
-        match Build_config.system with
-          | "macosx" -> "libSDL2_image-2.0.0.dylib"
-          | _ -> "libSDL2_image-2.0.so.0"
-      in
-      Dl.(dlopen ~filename ~flags:[RTLD_NOW])
+    let filename =
+      match Build_config.system with
+        | "macosx" -> "libSDL2_image-2.0.0.dylib"
+        | _ -> "libSDL2_image-2.0.so.0"
     in
-    foreign name typ ~from:dllib)
-  else foreign name typ
+    Some Dl.(dlopen ~filename ~flags:[RTLD_NOW]))
+  else
+    None
+
+let foreign = foreign ?from:dllib
 
 let init =
   foreign "IMG_Init" (uint32_t @-> returning uint32_t)


### PR DESCRIPTION
The shared library name is different on `macox`. This PR adds a build config which allows to pick the right name.