### PR TITLE
Use SDL "system" category to log "Loading Sdl_image" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix typo environment lookup of `LIBSLD2_PATH` to be correct `LIBSDL2_PATH`
 * Locate `SDL2_image.dll` on Windows
+* Use SDL "system" category to log "Loading Sdl_image" message
 
 # 0.5 2022/11/30 trying to autodetect library path
 

--- a/src/tsdl_image.ml
+++ b/src/tsdl_image.ml
@@ -42,7 +42,8 @@ module Image = struct
      in the toplevel, see
      https://github.com/ocamllabs/ocaml-ctypes/issues/70 *)
   let from : Dl.library option =
-    Sdl.log "Loading Sdl_image, Target = %s" Build_config.system;
+     Sdl.(log_info Log.category_system
+       "Loading Sdl_image, Target = %s" Build_config.system);
     let env = try Sys.getenv "LIBSDL2_PATH" with Not_found -> "" in
     let filename, path =
       match Build_config.system with


### PR DESCRIPTION
Same reason as for Tsdl_ttf (see https://github.com/sanette/tsdl-ttf/issues/6)